### PR TITLE
Fixed the copyright company

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 The MIT License
 
-Copyright (c) 2010-2011 Stripe (http://stripe.com)
+Copyright (c) 2012-2015 BASE, inc. (https://pay.jp)
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
Hi, there. I think this client library is not belong to Stripe, inc. 
so I just fixed the company name which is belong to copyright.

If it's rihgt, please merge this PR.