### PR TITLE
Allow passing payjp_account and api_base to PayjpObject.retrieve() and PayjpObject.all()

### DIFF
--- a/payjp/test/helper.py
+++ b/payjp/test/helper.py
@@ -109,8 +109,8 @@ class PayjpApiTestCase(PayjpTestCase):
         super(PayjpApiTestCase, self).setUp()
 
         self.requestor_patcher = patch('payjp.api_requestor.APIRequestor')
-        requestor_class_mock = self.requestor_patcher.start()
-        self.requestor_mock = requestor_class_mock.return_value
+        self.requestor_class_mock = self.requestor_patcher.start()
+        self.requestor_mock = self.requestor_class_mock.return_value
 
     def tearDown(self):
         super(PayjpApiTestCase, self).tearDown()


### PR DESCRIPTION
While we use the library on our sandbox environment, no clean way is provided to specify the base URL for the API endpoints.  This patch adds a limited support for such a usage.