### PR TITLE
Fixed error when getting instance_url from resources without id

### DIFF
--- a/payjp/error.py
+++ b/payjp/error.py
@@ -36,10 +36,6 @@ class CardError(PayjpException):
         self.code = code 
 
 
-class InvalidRequestError(PayjpException):
-    pass
-
-
 class AuthenticationError(PayjpException):
     pass
 

--- a/payjp/resource.py
+++ b/payjp/resource.py
@@ -256,7 +256,8 @@ class APIResource(PayjpObject):
     def instance_url(self):
         id = self.get('id')
         if not id:
-            raise error.InvalidRequestError
+            raise error.InvalidRequestError("Could not create instance url without it's id",
+                                            None)
 
         base = self.class_url()
         ext = quote_plus(id)

--- a/payjp/test/test_resources.py
+++ b/payjp/test/test_resources.py
@@ -194,6 +194,12 @@ class ListObjectTests(PayjpApiTestCase):
 
 class APIResourceTests(PayjpApiTestCase):
 
+    def test_instance_url_without_id(self):
+        from payjp.error import InvalidRequestError
+        resource = MyResource.construct_from({'id': None}, 'mykey')
+        with self.assertRaises(InvalidRequestError):
+            resource.instance_url()
+
     def test_retrieve_and_refresh(self):
         self.mock_response({
             'id': 'foo2',


### PR DESCRIPTION
Creating resource without `id` and getting `instance_url` will raise `TypeError`

```python
Traceback (most recent call last):
  File "/Users/user1/dev/payjp-python/payjp/test/test_resources.py", line 201, in test_instance_url_without_id
    resource.instance_url()
  File "/Users/user1/dev/payjp-python/payjp/resource.py", line 259, in instance_url
    raise error.InvalidRequestError
TypeError: __init__() takes at least 3 arguments (1 given)
```

I added a test to detect it and fixed.

## Cases

I think this case is not rare.
Because it will happen on calling `retrieve` with `None`.

```python
subscription = ...  # Creating local object
subscription.payjp_id = None  # and it has `id` on payjp as optional (like Null-able field on Django model)

import payjp
payjp.Subscription.retrieve(subscription.payjp_id)  # raise TypeError
```
