### PR TITLE
add balance statement URL

### DIFF
--- a/payjp/resource.py
+++ b/payjp/resource.py
@@ -436,6 +436,13 @@ class Term(ListableAPIResource):
 
 
 class Balance(ListableAPIResource):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        object.__setattr__(self, 'statement_urls', self.__statement_urls)
+
+    def __statement_urls(self, *args, **kwargs):
+        return self.__class__.statement_urls(self.get('id'), *args, **kwargs)
+
     @classmethod
     def statement_urls(cls, id, api_key=None, payjp_account=None, api_base=None, **params):
         requestor = api_requestor.APIRequestor(api_key, account=payjp_account, api_base=api_base)

--- a/payjp/resource.py
+++ b/payjp/resource.py
@@ -436,4 +436,9 @@ class Term(ListableAPIResource):
 
 
 class Balance(ListableAPIResource):
-    pass
+    @classmethod
+    def statement_urls(cls, id, api_key=None, payjp_account=None, api_base=None, **params):
+        requestor = api_requestor.APIRequestor(api_key, account=payjp_account, api_base=api_base)
+        url = cls.class_url() + f'/{id}/statement_urls'
+        response, api_key = requestor.request('post', url, params)
+        return convert_to_payjp_object(response, api_key, payjp_account, api_base)

--- a/payjp/test/test_resources.py
+++ b/payjp/test/test_resources.py
@@ -1218,5 +1218,13 @@ class BalanceTest(PayjpResourceTest):
             {},
         )
 
+        balance = payjp.Balance.retrieve('ba_xxx')
+        balance.statement_urls()
+        self.requestor_mock.request.assert_called_with(
+            'post',
+            '/v1/balances/ba_xxx/statement_urls',
+            {},
+        )
+
 if __name__ == '__main__':
     unittest.main()

--- a/payjp/test/test_resources.py
+++ b/payjp/test/test_resources.py
@@ -1210,6 +1210,13 @@ class BalanceTest(PayjpResourceTest):
             None
         )
 
+    def test_statement_urls(self):
+        payjp.Balance.statement_urls('ba_xxx')
+        self.requestor_mock.request.assert_called_with(
+            'post',
+            '/v1/balances/ba_xxx/statement_urls',
+            {},
+        )
 
 if __name__ == '__main__':
     unittest.main()

--- a/payjp/version.py
+++ b/payjp/version.py
@@ -1,1 +1,1 @@
-VERSION = '0.4.0'
+VERSION = '0.4.1'

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ install_requires.append('six >= 1.9.0')
 
 setup(
     name="payjp",
-    version="0.4.0",
+    version="0.4.1",
     description='PAY.JP python bindings',
     author="PAY.JP",
     author_email='support@pay.jp',


### PR DESCRIPTION
- this is version 0.4.1
- add feature that issue balance statement URL like [statement URL](https://pay.jp/docs/api/#%E5%8F%96%E5%BC%95%E6%98%8E%E7%B4%B0%E3%83%80%E3%82%A6%E3%83%B3%E3%83%AD%E3%83%BC%E3%83%89url%E3%82%92%E7%99%BA%E8%A1%8C)
- example usage:
```
statement_url = payjp.Balance.statement_urls('ba_xxxxxxxxxxxxxxxxxxxxxxxxxxxxx')
statement_url = payjp.Balance.statement_urls('ba_xxxxxxxxxxxxxxxxxxxxxxxxxxxxx', platformer='true')
```