### PR TITLE
fix(http_client): :pencil2: Correct support email address shown in some error messages

### DIFF
--- a/payjp/http_client.py
+++ b/payjp/http_client.py
@@ -55,7 +55,7 @@ class RequestsClient(HTTPClient):
             msg = (
                 "Unexpected error communicating with Payjp.  "
                 "If this problem persists, let us know at "
-                "support@payjp.com."
+                "support@pay.jp."
             )
             err = "%s: %s" % (type(e).__name__, str(e))
         else:
@@ -63,7 +63,7 @@ class RequestsClient(HTTPClient):
                 "Unexpected error communicating with Payjp. "
                 "It looks like there's probably a configuration "
                 "issue locally.  If this problem persists, let us "
-                "know at support@payjp.com."
+                "know at support@pay.jp."
             )
             err = "A %s was raised" % (type(e).__name__,)
             if str(e):


### PR DESCRIPTION
This change updates the support email address in 2 error messages.

* Updated the support email address to `support@pay.jp` in the `_handle_request_error` method
  * This makes it consistent with the `author_email` value defined in `setup.py` https://github.com/payjp/payjp-python/blob/6fea937f3484c382de87c29e39240b7cef7fa38c/setup.py#L19
  * The old value was a stub, I believe.